### PR TITLE
RtspVideoProps only contains required props

### DIFF
--- a/src/components/RtspVideo.tsx
+++ b/src/components/RtspVideo.tsx
@@ -2,7 +2,7 @@ import { CogsRtspStreamer } from '@clockworkdog/cogs-client';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import usePageVisibility from '../hooks/usePageVisibility';
 
-export interface RtspVideoProps extends React.DetailedHTMLProps<React.VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement> {
+export interface RtspVideoProps {
   uri: string;
   websocketHostname?: string;
   websocketPort?: number;
@@ -14,7 +14,13 @@ export interface RtspVideoProps extends React.DetailedHTMLProps<React.VideoHTMLA
  * websocket on the same hostname as COGS is running, but can be configured by passing in custom
  * websocket details.
  */
-export default function RtspVideo({ uri, websocketHostname, websocketPort, websocketPath, ...rest }: RtspVideoProps): JSX.Element | null {
+export default function RtspVideo({
+  uri,
+  websocketHostname,
+  websocketPort,
+  websocketPath,
+  ...rest
+}: RtspVideoProps & React.DetailedHTMLProps<React.VideoHTMLAttributes<HTMLVideoElement>, HTMLVideoElement>): JSX.Element | null {
   // We need to monitor the page visibility as we only want the stream to play when the page is visible
   // This is needed because the stream will "pause" when the page looses focus and start playback when it
   // becomes visible again. This will essentially cause a delay to be introduced into the stream when loosing


### PR DESCRIPTION
This tidies up the documentation for `RtspProps` a fair bit so it's easier to see what's happening.

<img width="831" alt="image" src="https://user-images.githubusercontent.com/292958/185392749-f7ee1cb4-2c03-45a5-8fdf-b65dd9820d2e.png">

---

Before:

<img width="581" alt="image" src="https://user-images.githubusercontent.com/292958/185392788-b9addf53-3441-407c-8592-98a791d9ad0e.png">
